### PR TITLE
docs: update fuelup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ The best way to get started building decentralized applications on Fuel! Built u
 
 2. The **Fuel toolchain** is required to compile Sway contracts & run them on the FuelVM. Install the Fuel toolchain by the command below; you can also find the steps [here](https://github.com/FuelLabs/fuelup)
 
-    `$curl --proto '=https' --tlsv1.2 -sSf \ https://fuellabs.github.io/fuelup/fuelup-init.sh | sh`
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh
+```
 
 3. The [beta-2 network](https://fuellabs.github.io/fuel-docs/master/networks/beta-1.html) is the second public Fuel testnet. Install the beta-2 toolchain by using the following command:
     `fuelup toolchain install beta-2`


### PR DESCRIPTION
the fuelup installation link is outdated, this just updates the README to reflect this!